### PR TITLE
Fix product fieldset persistence issue by removing WooCommerce query limit

### DIFF
--- a/src/FieldsetAssignment.php
+++ b/src/FieldsetAssignment.php
@@ -215,7 +215,8 @@ class FieldsetAssignment
         $result = array();
         if (is_array($products)) {
             $products = wc_get_products(array(
-                'include' => $products
+                'include' => $products,
+                'limits' => -1
             ));
 
             foreach ($products as $product) {

--- a/src/FieldsetProduct.php
+++ b/src/FieldsetProduct.php
@@ -191,6 +191,9 @@ class FieldsetProduct
         if (!isset($this->data->fieldset)) {
             return;
         }
+        
+        $this->fields = array();
+        
         if (is_array($this->data->fieldset)) {
             foreach ($this->data->fieldset as $name => $data) {
                 $FieldClass = "\\WCKalkulator\\Fields\\" . ucfirst($data["type"]) . "Field";


### PR DESCRIPTION
This PR fixes an issue where saving more than 10 products in a fieldset caused some products to disappear after saving and reloading the fieldset. The issue was due to WooCommerce’s default product query limit of 10, which prevented all selected products from being retrieved when reloading the fieldset.

**Bug Effects**
If more than 10 product IDs were stored in the fieldset, only the first 10 (based on WooCommerce’s internal query order) were loaded.
Any products beyond this limit were not displayed in the fieldset after reloading.
If the user saved again without noticing the missing products, they would be permanently removed from the fieldset.

**Fix**
Updated the wc_get_products() query to explicitly set 'limit' => -1, ensuring all selected products are always retrieved.
This prevents products from being unintentionally excluded and removed upon subsequent saves.